### PR TITLE
Update zuul pipeline to use the new version trigger build job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -14,7 +14,9 @@
       jobs:
         - trigger-build:
             vars:
-              webhook_url: https://paas.upshift.redhat.com/oapi/v1/namespaces/thoth-test-core/buildconfigs/graph-refresh-job
+              cluster: "paas.psi.redhat.com"
+              namespace: "thoth-test-core"
+              buildConfigName: "graph-refresh-job"
     release:
       jobs:
         - upload-pypi-sesheta

--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -61,7 +61,7 @@ objects:
         - type: Generic
           generic:
             secretReference:
-              name: zuul-incoming-webhook
+              name: generic-webhook-secret
 
 parameters:
   - description: Name of the GitHub repository for Thoth's Graph Refresh Job


### PR DESCRIPTION
Update generic trigger to buildconfig to use new generic webhook secret.
The generic-webhook-secret secret is a prerequisite for using this new build config.
Update the zuul config to use the new trigger build job API in zuul-config.