### PR TITLE
Fix error when serializing parameters to JSON

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,7 +94,7 @@ def graph_refresh() -> None:
     graph = GraphDatabase()
     graph.connect()
 
-    indexes = graph.get_python_package_index_urls()
+    indexes = list(graph.get_python_package_index_urls())
 
     openshift = OpenShift()
 


### PR DESCRIPTION
With transition to Dgraph, we retrieve a set of URLs for Python package
indexes. As these URLs are later on serialized into JSON, we need to explicitly
cast them to a list so they are JSON serializable.

Fixes: https://github.com/thoth-station/graph-refresh-job/issues/207