### PR TITLE
Add liveness probe

### DIFF
--- a/openshift/cronJob-template.yaml
+++ b/openshift/cronJob-template.yaml
@@ -160,4 +160,10 @@ objects:
                     limits:
                       memory: "256Mi"
                       cpu: "500m"
+                  livenessProbe:
+                    failureThreshold: 1
+                    initialDelaySeconds: 1800
+                    periodSeconds: 10
+                    tcpSocket:
+                      port: 80
               restartPolicy: OnFailure


### PR DESCRIPTION
The cronjob is stuck in the cluster. Let's create a liveness probe which fails
after certain period of time and the job gets restarted.