### PR TITLE
flush all pending messages

### DIFF
--- a/producer.py
+++ b/producer.py
@@ -280,6 +280,7 @@ def main() -> None:
                     "Failed to publish SI unanalyzed package message with the following error message: %r",
                     identifier,
                 )
+    p.flush()
 
     _METRIC_MESSSAGES_SENT.labels(
         message_type=unresolved_package_message.topic_name,


### PR DESCRIPTION
if program terminates before messages are sent by librdkafka they will be lost. `flush` will send all pending messages.